### PR TITLE
Project and target updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ obj
 bin
 /packages
 *.bak
+/.idea
+/_ReSharper.Caches

--- a/Jolt.Test/ConvertTestFixture.cs
+++ b/Jolt.Test/ConvertTestFixture.cs
@@ -131,10 +131,6 @@ namespace Jolt.Test
             Assert.That(
                 Convert.ToXmlDocCommentMember(IndexerType<int, int>.Indexer_3),
                 Is.EqualTo("P:Jolt.Test.Types.IndexerType`2.Item(`0[],System.Action{System.Action{`1}[0:,0:][]}[][],`0[0:,0:,0:,0:][0:,0:,0:][0:,0:][])"));
-
-            Assert.That(
-                Convert.ToXmlDocCommentMember(PointerTestType<int>.Property),
-                Is.EqualTo("P:Jolt.Test.Types.PointerTestType`1.Item(System.Int32*[],System.Action{System.Action{`0[]}[][]}[],System.Int16***[0:,0:,0:][0:,0:][])"));
         }
 
         /// <summary>
@@ -145,12 +141,12 @@ namespace Jolt.Test
         public void ToXmlDocCommentMember_Constructor()
         {
             Assert.That(
-                Convert.ToXmlDocCommentMember(typeof(System.Collections.Generic.List<>).GetConstructor(NonPublicStatic, null, Type.EmptyTypes, null)),
-                Is.EqualTo("M:System.Collections.Generic.List`1.#cctor"));
+                Convert.ToXmlDocCommentMember(typeof(System.Collections.Generic.List<>).GetConstructor(PublicInstance, null, Type.EmptyTypes, null)),
+                Is.EqualTo("M:System.Collections.Generic.List`1.#ctor"));
 
             Assert.That(
-                Convert.ToXmlDocCommentMember(typeof(string).GetConstructor(NonPublicStatic, null, Type.EmptyTypes, null)),
-                Is.EqualTo("M:System.String.#cctor"));
+                Convert.ToXmlDocCommentMember(typeof(string).GetConstructor(new [] {typeof(char), typeof(int)})),
+                Is.EqualTo("M:System.String.#ctor(System.Char,System.Int32)"));
 
             Assert.That(
                 Convert.ToXmlDocCommentMember(typeof(Exception).GetConstructor(Type.EmptyTypes)),
@@ -171,10 +167,6 @@ namespace Jolt.Test
             Assert.That(
                 Convert.ToXmlDocCommentMember(ConstructorType<int, int>.Constructor_3),
                 Is.EqualTo("M:Jolt.Test.Types.ConstructorType`2.#ctor(`0[],System.Action{System.Action{System.Action{`1}[][]}[]}[][]@,`1[0:,0:,0:,0:][0:,0:,0:][0:,0:][])"));
-
-            Assert.That(
-                Convert.ToXmlDocCommentMember(PointerTestType<int>.Constructor),
-                Is.EqualTo("M:Jolt.Test.Types.PointerTestType`1.#ctor(System.Action{`0[]}[],System.String***[0:,0:,0:][0:,0:][]@)"));
         }
 
         /// <summary>
@@ -203,10 +195,6 @@ namespace Jolt.Test
             Assert.That(
                 Convert.ToXmlDocCommentMember(typeof(Enumerable).GetMethods().Single(m => m.Name == "ToLookup" && m.GetParameters().Length == 4)),
                 Is.EqualTo("M:System.Linq.Enumerable.ToLookup``3(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Func{``0,``2},System.Collections.Generic.IEqualityComparer{``1})"));
-
-            Assert.That(
-                Convert.ToXmlDocCommentMember(PointerTestType<int>.Method),
-                Is.EqualTo("M:Jolt.Test.Types.PointerTestType`1._method``1(System.Int32,`0[0:,0:]@,System.Action{``0[0:,0:][]}*[][0:,0:]@,System.Action{System.Int32**[0:,0:,0:][]})"));
         }
 
         /// <summary>
@@ -462,6 +450,9 @@ namespace Jolt.Test
         #endregion
 
         #region private fields --------------------------------------------------------------------
+
+        private static readonly BindingFlags PublicInstance = BindingFlags.Instance | BindingFlags.Public;
+        private static readonly BindingFlags PublicStatic = BindingFlags.Static | BindingFlags.Public;
 
         private static readonly BindingFlags NonPublicInstance = BindingFlags.Instance | BindingFlags.NonPublic;
         private static readonly BindingFlags NonPublicStatic = BindingFlags.Static | BindingFlags.NonPublic;

--- a/Jolt.Test/DefaultXDCReadPolicyTestFixture.cs
+++ b/Jolt.Test/DefaultXDCReadPolicyTestFixture.cs
@@ -14,7 +14,6 @@ using System.Xml.Schema;
 
 using Jolt.IO;
 using NUnit.Framework;
-using Rhino.Mocks;
 
 namespace Jolt.Test
 {
@@ -31,9 +30,9 @@ namespace Jolt.Test
         {
             using (StreamReader expectedReader = OpenDocCommentsXml())
             {
-                base.Constructrion_Internal(
+                base.Construction_Internal(
                     CreatePolicy,
-                    (expectedFilename, fileProxy) => fileProxy.Expect(f => f.OpenText(expectedFilename)).Return(expectedReader),
+                    (expectedFilename, fileProxy) => fileProxy.Setup(f => f.OpenText(expectedFilename)).Returns(expectedReader).Verifiable(),
                     p => Assert.That(expectedReader.BaseStream.Position, Is.EqualTo(expectedReader.BaseStream.Length)));
             }
         }
@@ -42,16 +41,21 @@ namespace Jolt.Test
         /// Verifies the construction of the class when the given
         /// XML doc comment file is invalid.
         /// </summary>
-        [Test, ExpectedException(typeof(XmlSchemaValidationException))]
+        [Test]
         public void Construction_InvalidXml()
         {
-            using (StreamReader expectedReader = new StreamReader(new MemoryStream(Encoding.Default.GetBytes("<invalidXml/>"))))
+            Assert.Throws<XmlSchemaValidationException>(() =>
             {
-                base.Constructrion_Internal(
-                    CreatePolicy,
-                    (expectedFilename, fileProxy) => fileProxy.Expect(f => f.OpenText(expectedFilename)).Return(expectedReader),
-                    NullAssert);
-            }
+                using (StreamReader expectedReader =
+                    new StreamReader(new MemoryStream(Encoding.Default.GetBytes("<invalidXml/>"))))
+                {
+                    base.Construction_Internal(
+                        CreatePolicy,
+                        (expectedFilename, fileProxy) =>
+                            fileProxy.Setup(f => f.OpenText(expectedFilename)).Returns(expectedReader).Verifiable(),
+                        NullAssert);
+                }
+            });
         }
 
         /// <summary>

--- a/Jolt.Test/Functional/CompositeTestFixture.cs
+++ b/Jolt.Test/Functional/CompositeTestFixture.cs
@@ -1,2624 +1,313 @@
-// ----------------------------------------------------------------------------
-// CompositeTestFixture.cs
-//
-// Contains the definition of the CompositeTestFixture class.
-// Copyright 2009 Steve Guidi.
-//
-// File created: 4/29/2009 08:10:06
-// ----------------------------------------------------------------------------
-
 using System;
-using System.Text;
-
 using Jolt.Functional;
 using NUnit.Framework;
-using Rhino.Mocks;
 
 namespace Jolt.Test.Functional
 {
     [TestFixture]
     public sealed class CompositeTestFixture
     {
-        #region public methods --------------------------------------------------------------------
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting one argument, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void First_Func_OneArg_Compose_ZeroArgFunc()
+        public void Compose_2ArgFunc_With2ArgFunc_First()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<string> boundFunction = Compose.First(FuncToBind_1Arg_ForFirst, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                Assert.That(boundFunction(), Is.EqualTo(InnerFunctionResult.ToString()));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting one argument, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Func_OneArg_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<int, string> boundFunction = Compose.First(FuncToBind_1Arg_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                Assert.That(boundFunction(i), Is.EqualTo(InnerFunctionResult.ToString()));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting one argument, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_OneArg_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<int, TimeSpan, string> boundFunction = Compose.First(FuncToBind_1Arg_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i)), Is.EqualTo(InnerFunctionResult.ToString()));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting one argument, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_OneArg_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<int, TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_1Arg_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i), Is.EqualTo(InnerFunctionResult.ToString()));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting one argument, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_OneArg_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_1Arg_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday), Is.EqualTo(InnerFunctionResult.ToString()));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_TwoArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, string> boundFunction = Compose.First(FuncToBind_2Args_ForFirst, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Func_TwoArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<int, TimeSpan, string> boundFunction = Compose.First(FuncToBind_2Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(i, functionArg), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_TwoArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<int, TimeSpan, TimeSpan, string> boundFunction = Compose.First(FuncToBind_2Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), functionArg),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_TwoArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<int, TimeSpan, double, TimeSpan, string> boundFunction = Compose.First(FuncToBind_2Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_TwoArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<int, TimeSpan, double, DayOfWeek, TimeSpan, string> boundFunction = Compose.First(FuncToBind_2Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_ThreeArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_3Args_ForFirst, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Func_ThreeArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<int, TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_3Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(i, functionArg_1, functionArg_2),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_ThreeArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<int, TimeSpan, TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_3Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), functionArg_1, functionArg_2),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_ThreeArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<int, TimeSpan, double, TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_3Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg_1, functionArg_2),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_ThreeArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<int, TimeSpan, double, DayOfWeek, TimeSpan, double, string> boundFunction = Compose.First(FuncToBind_3Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_1, functionArg_2),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_4Args_ForFirst, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Func_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_4Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(i, functionArg_1, functionArg_2, functionArg_3),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_FourArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<int, TimeSpan, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_4Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), functionArg_1, functionArg_2, functionArg_3),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<int, TimeSpan, double, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_4Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg_1, functionArg_2, functionArg_3),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Func_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<int, TimeSpan, double, DayOfWeek, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.First(FuncToBind_4Args_ForFirst, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_1, functionArg_2, functionArg_3),
-                    Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting one argument, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_OneArg_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action boundFunction = Compose.First(CreateActionToBind_1Arg_ForFirst(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                boundFunction();
-
-                Assert.That(builder.ToString(), Is.EqualTo(InnerFunctionResult.ToString()));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting one argument, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Action_OneArg_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int> boundFunction = Compose.First(CreateActionToBind_1Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                boundFunction(i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(InnerFunctionResult.ToString()));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting one argument, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_OneArg_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan> boundFunction = Compose.First(CreateActionToBind_1Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                boundFunction(i, TimeSpan.FromDays(i));
-
-                Assert.That(builder.ToString(), Is.EqualTo(InnerFunctionResult.ToString()));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting one argument, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_OneArg_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_1Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(InnerFunctionResult.ToString()));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting one argument, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_OneArg_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_1Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday);
-
-                Assert.That(builder.ToString(), Is.EqualTo(InnerFunctionResult.ToString()));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_TwoArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan> boundFunction = Compose.First(CreateActionToBind_2Arg_ForFirst(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Action_TwoArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan> boundFunction = Compose.First(CreateActionToBind_2Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(i, functionArg);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_TwoArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, TimeSpan> boundFunction = Compose.First(CreateActionToBind_2Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(i, TimeSpan.FromDays(i), functionArg);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_TwoArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, TimeSpan> boundFunction = Compose.First(CreateActionToBind_2Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_TwoArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, DayOfWeek, TimeSpan> boundFunction = Compose.First(CreateActionToBind_2Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_ThreeArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_3Arg_ForFirst(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Action_ThreeArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_3Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(i, functionArg_1, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_ThreeArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_3Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(i, TimeSpan.FromDays(i), functionArg_1, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_ThreeArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_3Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg_1, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_ThreeArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, DayOfWeek, TimeSpan, double> boundFunction = Compose.First(CreateActionToBind_3Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_1, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_4Arg_ForFirst(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void First_Action_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_4Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(i, functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_FourArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_4Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(i, TimeSpan.FromDays(i), functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create2ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_4Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the First() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void First_Action_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<int, TimeSpan, double, DayOfWeek, TimeSpan, double, DayOfWeek> boundFunction = Compose.First(CreateActionToBind_4Arg_ForFirst(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(InnerFunctionResult, functionArg_1, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_TwoArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, string> boundFunction = Compose.Second(FuncToBind_2Args_ForSecond, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Second_Func_TwoArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, int, string> boundFunction = Compose.Second(FuncToBind_2Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg, i), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_TwoArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, int, TimeSpan, string> boundFunction = Compose.Second(FuncToBind_2Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg, i, TimeSpan.FromDays(i)), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_TwoArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, int, TimeSpan, double, string> boundFunction = Compose.Second(FuncToBind_2Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg, i, TimeSpan.FromDays(i), 2.5 * i), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>s
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_TwoArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_2Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                Assert.That(boundFunction(functionArg, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_ThreeArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, string> boundFunction = Compose.Second(FuncToBind_3Args_ForSecond, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Second_Func_ThreeArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, int, double, string> boundFunction = Compose.Second(FuncToBind_3Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, i, functionArg_2), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_ThreeArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, int, TimeSpan, double, string> boundFunction = Compose.Second(FuncToBind_3Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), functionArg_2), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.First(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_ThreeArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, int, TimeSpan, double, double, string> boundFunction = Compose.Second(FuncToBind_3Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_2), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>s
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_ThreeArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, int, TimeSpan, double, DayOfWeek, double, string> boundFunction = Compose.Second(FuncToBind_3Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_2), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_4Args_ForSecond, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Second_Func_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, int, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_4Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, i, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c"), Is.EqualTo("a,b|c"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Second_Func_FourArgs_Compose_TwoArgFunc()
+        public void Compose_2ArgFunc_With2ArgFunc_Second()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_4Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create2ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, int, TimeSpan, double, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_4Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Second(outer, inner);
 
-        /// <summary>s
-        /// Verifies the behavior of the Second() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Second_Func_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, int, TimeSpan, double, DayOfWeek, double, DayOfWeek, string> boundFunction = Compose.Second(FuncToBind_4Args_ForSecond, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c"), Is.EqualTo("a|b,c"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_TwoArgs_Compose_ZeroArgFunc()
+        public void Compose_2ArgFunc_With3ArgFunc_First()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan> boundFunction = Compose.Second(CreateActionToBind_2Arg_ForSecond(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg);
+            var outer = Create2ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-                builder.Length = 0;
-            }
+            var composed = Compose.First(outer, inner);
 
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d"), Is.EqualTo("a,b,c|d"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
         [Test]
-        public void Second_Action_TwoArgs_Compose_OneArgFunc()
+        public void Compose_2ArgFunc_With3ArgFunc_Second()
         {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
+            var outer = Create2ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int> boundFunction = Compose.Second(CreateActionToBind_2Arg_ForSecond(builder), innerFunction);
+            var composed = Compose.Second(outer, inner);
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg, i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d"), Is.EqualTo("a|b,c,d"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_TwoArgs_Compose_TwoArgFunc()
+        public void Compose_2ArgFunc_With4ArgFunc_First()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan> boundFunction = Compose.Second(CreateActionToBind_2Arg_ForSecond(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg, i, TimeSpan.FromDays(i));
+            var outer = Create2ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-                builder.Length = 0;
-            }
+            var composed = Compose.First(outer, inner);
 
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a,b,c,d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_TwoArgs_Compose_ThreeArgFunc()
+        public void Compose_2ArgFunc_With4ArgFunc_Second()
         {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
+            var outer = Create2ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double> boundFunction = Compose.Second(CreateActionToBind_2Arg_ForSecond(builder), innerFunction);
+            var composed = Compose.Second(outer, inner);
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg, i, TimeSpan.FromDays(i), 2.5 * i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b,c,d,e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting two arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_TwoArgs_Compose_FourArgFunc()
+        public void Compose_3ArgFunc_With2ArgFunc_First()
         {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_2Arg_ForSecond(builder), innerFunction);
+            var outer = Create3ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg = TimeSpan.FromTicks(i);
-                boundFunction(functionArg, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday);
+            var composed = Compose.First(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d"), Is.EqualTo("a,b|c|d"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_ThreeArgs_Compose_ZeroArgFunc()
+        public void Compose_3ArgFunc_With2ArgFunc_Second()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double> boundFunction = Compose.Second(CreateActionToBind_3Arg_ForSecond(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2);
+            var outer = Create3ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-                builder.Length = 0;
-            }
+            var composed = Compose.Second(outer, inner);
 
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d"), Is.EqualTo("a|b,c|d"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
         [Test]
-        public void Second_Action_ThreeArgs_Compose_OneArgFunc()
+        public void Compose_3ArgFunc_With2ArgFunc_Third()
         {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
+            var outer = Create3ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, double> boundFunction = Compose.Second(CreateActionToBind_3Arg_ForSecond(builder), innerFunction);
+            var composed = Compose.Third(outer, inner);
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, i, functionArg_2);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d"), Is.EqualTo("a|b|c,d"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_ThreeArgs_Compose_TwoArgFunc()
+        public void Compose_3ArgFunc_With3ArgFunc_First()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double> boundFunction = Compose.Second(CreateActionToBind_3Arg_ForSecond(builder), innerFunction);
+            var outer = Create3ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), functionArg_2);
+            var composed = Compose.First(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a,b,c|d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_ThreeArgs_Compose_ThreeArgFunc()
+        public void Compose_3ArgFunc_With3ArgFunc_Second()
         {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, double> boundFunction = Compose.Second(CreateActionToBind_3Arg_ForSecond(builder), innerFunction);
+            var outer = Create3ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_2);
+            var composed = Compose.Second(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b,c,d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_ThreeArgs_Compose_FourArgFunc()
+        public void Compose_3ArgFunc_With3ArgFunc_Third()
         {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, DayOfWeek, double> boundFunction = Compose.Second(CreateActionToBind_3Arg_ForSecond(builder), innerFunction);
+            var outer = Create3ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_2);
+            var composed = Compose.Third(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b|c,d,e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_FourArgs_Compose_ZeroArgFunc()
+        public void Compose_3ArgFunc_With4ArgFunc_First()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_4Arg_ForSecond(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create3ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Second_Action_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_4Arg_ForSecond(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, i, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.First(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Second_Action_FourArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_4Arg_ForSecond(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a,b,c,d|e|f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
         [Test]
-        public void Second_Action_FourArgs_Compose_ThreeArgFunc()
+        public void Compose_3ArgFunc_With4ArgFunc_Second()
         {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_4Arg_ForSecond(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create3ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Second() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Second_Action_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, int, TimeSpan, double, DayOfWeek, double, DayOfWeek> boundFunction = Compose.Second(CreateActionToBind_4Arg_ForSecond(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, InnerFunctionResult, functionArg_2, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Second(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_ThreeArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, string> boundFunction = Compose.Third(FuncToBind_3Args_ForThird, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a|b,c,d,e|f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
         [Test]
-        public void Third_Func_ThreeArgs_Compose_OneArgFunc()
+        public void Compose_3ArgFunc_With4ArgFunc_Third()
         {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, double, int, string> boundFunction = Compose.Third(FuncToBind_3Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create3ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_ThreeArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, double, int, TimeSpan, string> boundFunction = Compose.Third(FuncToBind_3Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i)), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Third(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_ThreeArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, double, int, TimeSpan, double, string> boundFunction = Compose.Third(FuncToBind_3Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a|b|c,d,e,f"));
         }
 
-        /// <summary>s
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
         [Test]
-        public void Third_Func_ThreeArgs_Compose_FourArgFunc()
+        public void Compose_4ArgFunc_With2ArgFunc_First()
         {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, double, int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_3Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_4Args_ForThird, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.First(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Third_Func_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, double, int, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_4Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a,b|c|d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Third_Func_FourArgs_Compose_TwoArgFunc()
+        public void Compose_4ArgFunc_With2ArgFunc_Second()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, double, int, TimeSpan, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_4Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, double, int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_4Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Second(outer, inner);
 
-        /// <summary>s
-        /// Verifies the behavior of the Third() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Third_Func_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, double, int, TimeSpan, double, DayOfWeek, DayOfWeek, string> boundFunction = Compose.Third(FuncToBind_4Args_ForThird, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b,c|d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void Third_Action_ThreeArgs_Compose_ZeroArgFunc()
+        public void Compose_4ArgFunc_With2ArgFunc_Third()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double> boundFunction = Compose.Third(CreateActionToBind_3Arg_ForThird(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2);
+            var outer = Create4ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-                builder.Length = 0;
-            }
+            var composed = Compose.Third(outer, inner);
 
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b|c,d|e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
         [Test]
-        public void Third_Action_ThreeArgs_Compose_OneArgFunc()
+        public void Compose_4ArgFunc_With2ArgFunc_Fourth()
         {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
+            var outer = Create4ArgFunc('|');
+            var inner = Create2ArgFunc(',');
 
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int> boundFunction = Compose.Third(CreateActionToBind_3Arg_ForThird(builder), innerFunction);
+            var composed = Compose.Fourth(outer, inner);
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2, i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e"), Is.EqualTo("a|b|c|d,e"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Third_Action_ThreeArgs_Compose_TwoArgFunc()
+        public void Compose_4ArgFunc_With3ArgFunc_First()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan> boundFunction = Compose.Third(CreateActionToBind_3Arg_ForThird(builder), innerFunction);
+            var outer = Create4ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i));
+            var composed = Compose.First(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a,b,c|d|e|f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
         [Test]
-        public void Third_Action_ThreeArgs_Compose_ThreeArgFunc()
+        public void Compose_4ArgFunc_With3ArgFunc_Second()
         {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan, double> boundFunction = Compose.Third(CreateActionToBind_3Arg_ForThird(builder), innerFunction);
+            var outer = Create4ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i);
+            var composed = Compose.Second(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a|b,c,d|e|f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting three arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
         [Test]
-        public void Third_Action_ThreeArgs_Compose_FourArgFunc()
+        public void Compose_4ArgFunc_With3ArgFunc_Third()
         {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan, double, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_3Arg_ForThird(builder), innerFunction);
+            var outer = Create4ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday);
+            var composed = Compose.Third(outer, inner);
 
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Third_Action_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_4Arg_ForThird(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Third_Action_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_4Arg_ForThird(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, i, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a|b|c,d,e|f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
         [Test]
-        public void Third_Action_FourArgs_Compose_TwoArgFunc()
+        public void Compose_4ArgFunc_With3ArgFunc_Fourth()
         {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_4Arg_ForThird(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create3ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Third_Action_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan, double, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_4Arg_ForThird(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Fourth(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Third() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Third_Action_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, int, TimeSpan, double, DayOfWeek, DayOfWeek> boundFunction = Compose.Third(CreateActionToBind_4Arg_ForThird(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, InnerFunctionResult, functionArg_3)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f"), Is.EqualTo("a|b|c|d,e,f"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
         [Test]
-        public void Fourth_Func_FourArgs_Compose_ZeroArgFunc()
+        public void Compose_4ArgFunc_With4ArgFunc_First()
         {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-            Func<TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Fourth(FuncToBind_4Args_ForFourth, innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
-        [Test]
-        public void Fourth_Func_FourArgs_Compose_OneArgFunc()
-        {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-            Func<TimeSpan, double, DayOfWeek, int, string> boundFunction = Compose.Fourth(FuncToBind_4Args_ForFourth, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3, i), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.First(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Fourth_Func_FourArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-            Func<TimeSpan, double, DayOfWeek, int, TimeSpan, string> boundFunction = Compose.Fourth(FuncToBind_4Args_ForFourth, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i)), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f", "g"), Is.EqualTo("a,b,c,d|e|f|g"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
         [Test]
-        public void Fourth_Func_FourArgs_Compose_ThreeArgFunc()
+        public void Compose_4ArgFunc_With4ArgFunc_Second()
         {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-            Func<TimeSpan, double, DayOfWeek, int, TimeSpan, double, string> boundFunction = Compose.Fourth(FuncToBind_4Args_ForFourth, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i), 2.5 * i), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>s
-        /// Verifies the behavior of the Fourth() method, for functors
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
-        [Test]
-        public void Fourth_Func_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-            Func<TimeSpan, double, DayOfWeek, int, TimeSpan, double, DayOfWeek, string> boundFunction = Compose.Fourth(FuncToBind_4Args_ForFourth, innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                Assert.That(boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Second(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of zero arguments.
-        /// </summary>
-        [Test]
-        public void Fourth_Action_FourArgs_Compose_ZeroArgFunc()
-        {
-            Func<uint> innerFunction = InitializeMockInnerFunctionExpectations_0Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek> boundFunction = Compose.Fourth(CreateActionToBind_4Arg_ForFourth(builder), innerFunction);
-
-            for (uint i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f", "g"), Is.EqualTo("a|b,c,d,e|f|g"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of one argument.
-        /// </summary>
         [Test]
-        public void Fourth_Action_FourArgs_Compose_OneArgFunc()
+        public void Compose_4ArgFunc_With4ArgFunc_Third()
         {
-            Func<int, uint> innerFunction = InitializeMockInnerFunctionExpectations_1Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek, int> boundFunction = Compose.Fourth(CreateActionToBind_4Arg_ForFourth(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3, i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of two arguments.
-        /// </summary>
-        [Test]
-        public void Fourth_Action_FourArgs_Compose_TwoArgFunc()
-        {
-            Func<int, TimeSpan, uint> innerFunction = InitializeMockInnerFunctionExpectations_2Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek, int, TimeSpan> boundFunction = Compose.Fourth(CreateActionToBind_4Arg_ForFourth(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i));
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
+            var composed = Compose.Third(outer, inner);
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of three arguments.
-        /// </summary>
-        [Test]
-        public void Fourth_Action_FourArgs_Compose_ThreeArgFunc()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = InitializeMockInnerFunctionExpectations_3Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek, int, TimeSpan, double> boundFunction = Compose.Fourth(CreateActionToBind_4Arg_ForFourth(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i), 2.5 * i);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
+            Assert.That(composed("a", "b", "c", "d", "e", "f", "g"), Is.EqualTo("a|b|c,d,e,f|g"));
         }
 
-        /// <summary>
-        /// Verifies the behavior of the Fourth() method, for actions
-        /// accepting four arguments, when composing with an auxillary functor
-        /// of four arguments.
-        /// </summary>
         [Test]
-        public void Fourth_Action_FourArgs_Compose_FourArgFunc()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = InitializeMockInnerFunctionExpectations_4Arg();
-
-            StringBuilder builder = new StringBuilder();
-            Action<TimeSpan, double, DayOfWeek, int, TimeSpan, double, DayOfWeek> boundFunction = Compose.Fourth(CreateActionToBind_4Arg_ForFourth(builder), innerFunction);
-
-            for (int i = 0; i < 20; ++i)
-            {
-                TimeSpan functionArg_1 = TimeSpan.FromTicks(i);
-                double functionArg_2 = 5.5 * i;
-                DayOfWeek functionArg_3 = DayOfWeek.Thursday;
-                boundFunction(functionArg_1, functionArg_2, functionArg_3, i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday);
-
-                Assert.That(builder.ToString(), Is.EqualTo(String.Concat(functionArg_1, functionArg_2, functionArg_3, InnerFunctionResult)));
-                builder.Length = 0;
-            }
-
-            innerFunction.VerifyAllExpectations();
-        }
-
-        #endregion
-
-        #region private methods -------------------------------------------------------------------
-
-        /// <summary>
-        /// Creates a mock functor for use in composition tests,
-        /// registers its expectations, then shifts the mock repository
-        /// to verification mode.
-        /// </summary>
-        private static Func<uint> InitializeMockInnerFunctionExpectations_0Arg()
-        {
-            Func<uint> innerFunction = MockRepository.GenerateMock<Func<uint>>();
-
-            innerFunction.Expect(f => f()).Return(InnerFunctionResult).Repeat.Times(20);
-            return innerFunction;
-        }
-
-        /// <summary>
-        /// Creates a mock functor for use in composition tests,
-        /// registers its expectations, then shifts the mock repository
-        /// to verification mode.
-        /// </summary>
-        private static Func<int, uint> InitializeMockInnerFunctionExpectations_1Arg()
-        {
-            Func<int, uint> innerFunction = MockRepository.GenerateMock<Func<int, uint>>();
-
-            for (int i = 0; i < 20; ++i)
-            {
-                innerFunction.Expect(f => f(i)).Return(InnerFunctionResult);
-            }
-
-            return innerFunction;
-        }
-
-        /// <summary>
-        /// Creates a mock functor for use in composition tests,
-        /// registers its expectations, then shifts the mock repository
-        /// to verification mode.
-        /// </summary>
-        private static Func<int, TimeSpan, uint> InitializeMockInnerFunctionExpectations_2Arg()
-        {
-            Func<int, TimeSpan, uint> innerFunction = MockRepository.GenerateMock<Func<int, TimeSpan, uint>>();
-
-            for (int i = 0; i < 20; ++i)
-            {
-                innerFunction.Expect(f => f(i, TimeSpan.FromDays(i))).Return(InnerFunctionResult);
-            }
-
-            return innerFunction;
-        }
-
-        /// <summary>
-        /// Creates a mock functor for use in composition tests,
-        /// registers its expectations, then shifts the mock repository
-        /// to verification mode.
-        /// </summary>
-        private static Func<int, TimeSpan, double, uint> InitializeMockInnerFunctionExpectations_3Arg()
-        {
-            Func<int, TimeSpan, double, uint> innerFunction = MockRepository.GenerateMock<Func<int, TimeSpan, double, uint>>();
-
-            for (int i = 0; i < 20; ++i)
-            {
-                innerFunction.Expect(f => f(i, TimeSpan.FromDays(i), 2.5 * i)).Return(InnerFunctionResult);
-            }
-
-            return innerFunction;
-        }
-
-        /// <summary>
-        /// Creates a mock functor for use in composition tests,
-        /// registers its expectations, then shifts the mock repository
-        /// to verification mode.
-        /// </summary>
-        private static Func<int, TimeSpan, double, DayOfWeek, uint> InitializeMockInnerFunctionExpectations_4Arg()
-        {
-            Func<int, TimeSpan, double, DayOfWeek, uint> innerFunction = MockRepository.GenerateMock<Func<int, TimeSpan, double, DayOfWeek, uint>>();
-
-            for (int i = 0; i < 20; ++i)
-            {
-                innerFunction.Expect(f => f(i, TimeSpan.FromDays(i), 2.5 * i, DayOfWeek.Friday)).Return(InnerFunctionResult);
-            }
-
-            return innerFunction;
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<uint> CreateActionToBind_1Arg_ForFirst(StringBuilder builder)
-        {
-            return number => builder.Append(number);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<uint, TimeSpan> CreateActionToBind_2Arg_ForFirst(StringBuilder builder)
+        public void Compose_4ArgFunc_With4ArgFunc_Fourth()
         {
-            return (number, duration) => builder.Append(number).Append(duration);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<uint, TimeSpan, double> CreateActionToBind_3Arg_ForFirst(StringBuilder builder)
-        {
-            return (number, duration, ratio) => builder.Append(number).Append(duration).Append(ratio);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<uint, TimeSpan, double, DayOfWeek> CreateActionToBind_4Arg_ForFirst(StringBuilder builder)
-        {
-            return (number, duration, ratio, day) => builder.Append(number).Append(duration).Append(ratio).Append(day);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, uint> CreateActionToBind_2Arg_ForSecond(StringBuilder builder)
-        {
-            return (duration, number) => builder.Append(duration).Append(number);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, uint, double> CreateActionToBind_3Arg_ForSecond(StringBuilder builder)
-        {
-            return (duration, number, ratio) => builder.Append(duration).Append(number).Append(ratio);
-        }
+            var outer = Create4ArgFunc('|');
+            var inner = Create4ArgFunc(',');
 
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, uint, double, DayOfWeek> CreateActionToBind_4Arg_ForSecond(StringBuilder builder)
-        {
-            return (duration, number, ratio, day) => builder.Append(duration).Append(number).Append(ratio).Append(day);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, double, uint> CreateActionToBind_3Arg_ForThird(StringBuilder builder)
-        {
-            return (duration, ratio, number) => builder.Append(duration).Append(ratio).Append(number);
-        }
-
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, double, uint, DayOfWeek> CreateActionToBind_4Arg_ForThird(StringBuilder builder)
-        {
-            return (duration, ratio, number, day) => builder.Append(duration).Append(ratio).Append(number).Append(day);
-        }
+            var composed = Compose.Fourth(outer, inner);
 
-        /// <summary>
-        /// Creates an Action that when executed, appends the values of its
-        /// arguments to the given StringBuilder.
-        /// </summary>
-        /// 
-        /// <param name="builder">
-        /// The StringBuilder for which the resulting Action appends to.
-        /// </param>
-        private static Action<TimeSpan, double, DayOfWeek, uint> CreateActionToBind_4Arg_ForFourth(StringBuilder builder)
-        {
-            return (duration, ratio, day, number) => builder.Append(duration).Append(ratio).Append(day).Append(number);
+            Assert.That(composed("a", "b", "c", "d", "e", "f", "g"), Is.EqualTo("a|b|c|d,e,f,g"));
         }
-
-        #endregion
-
-        #region private fields --------------------------------------------------------------------
-
-        private static readonly uint InnerFunctionResult = 0xdeadbeef;
-
-        private static readonly Func<uint, string> FuncToBind_1Arg_ForFirst = number => number.ToString();
-        private static readonly Func<uint, TimeSpan, string> FuncToBind_2Args_ForFirst = (number, duration) => String.Concat(number, duration);
-        private static readonly Func<uint, TimeSpan, double, string> FuncToBind_3Args_ForFirst = (number, duration, ratio) => String.Concat(number, duration, ratio);
-        private static readonly Func<uint, TimeSpan, double, DayOfWeek, string> FuncToBind_4Args_ForFirst = (number, duration, ratio, day) => String.Concat(number, duration, ratio, day);
-
-        private static readonly Func<TimeSpan, uint, string> FuncToBind_2Args_ForSecond = (duration, number) => String.Concat(duration, number);
-        private static readonly Func<TimeSpan, uint, double, string> FuncToBind_3Args_ForSecond = (duration, number, ratio) => String.Concat(duration, number, ratio);
-        private static readonly Func<TimeSpan, uint, double, DayOfWeek, string> FuncToBind_4Args_ForSecond = (duration, number, ratio, day) => String.Concat(duration, number, ratio, day);
 
-        private static readonly Func<TimeSpan, double, uint, string> FuncToBind_3Args_ForThird = (duration, ratio, number) => String.Concat(duration, ratio, number);
-        private static readonly Func<TimeSpan, double, uint, DayOfWeek, string> FuncToBind_4Args_ForThird = (duration, ratio, number, day) => String.Concat(duration, ratio, number, day);
+        private static Func<string, string, string> Create2ArgFunc(char separator) => (a, b) => $"{a}{separator}{b}";
 
-        private static readonly Func<TimeSpan, double, DayOfWeek, uint, string> FuncToBind_4Args_ForFourth = (duration, ratio, day, number) => String.Concat(duration, ratio, day, number);
+        private static Func<string, string, string, string> Create3ArgFunc(char separator) => (a, b, c) => $"{a}{separator}{b}{separator}{c}";
 
-        #endregion
+        private static Func<string, string, string, string, string> Create4ArgFunc(char separator) => (a, b, c, d) => $"{a}{separator}{b}{separator}{c}{separator}{d}";
     }
 }

--- a/Jolt.Test/Functional/FunctorTestFixture.cs
+++ b/Jolt.Test/Functional/FunctorTestFixture.cs
@@ -13,8 +13,8 @@ using System.Linq;
 using System.Reflection;
 
 using Jolt.Functional;
+using Moq;
 using NUnit.Framework;
-using Rhino.Mocks;
 
 namespace Jolt.Test.Functional
 {
@@ -30,13 +30,13 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_NoArgs()
         {
-            Func<int> function = MockRepository.GenerateMock<Func<int>>();
-            function.Expect(f => f()).Return(0);
+            Mock<Func<int>> function = new Mock<Func<int>>();
+            function.Setup(f => f()).Returns(0).Verifiable();
 
-            Action action = Functor.ToAction(function);
+            Action action = Functor.ToAction(function.Object);
             action();
 
-            function.VerifyAllExpectations();
+            function.VerifyAll();
         }
 
         /// <summary>
@@ -46,15 +46,15 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_OneArg()
         {
-            Func<string, int> function = MockRepository.GenerateMock<Func<string, int>>();
+            Mock<Func<string, int>> function = new Mock<Func<string, int>>();
 
             string functionArg = "first-arg";
-            function.Expect(f => f(functionArg)).Return(0);
+            function.Setup(f => f(functionArg)).Returns(0).Verifiable();
 
-            Action<string> action = Functor.ToAction(function);
+            Action<string> action = Functor.ToAction(function.Object);
             action(functionArg);
 
-            function.VerifyAllExpectations();
+            function.VerifyAll();
         }
 
         /// <summary>
@@ -64,15 +64,15 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_TwoArgs()
         {
-            Func<string, Stream, int> function = MockRepository.GenerateMock<Func<string, Stream, int>>();
+            Mock<Func<string, Stream, int>> function = new Mock<Func<string, Stream, int>>();
 
             string functionArg = "first-arg";
-            function.Expect(f => f(functionArg, Stream.Null)).Return(0);
+            function.Setup(f => f(functionArg, Stream.Null)).Returns(0).Verifiable();
 
-            Action<string, Stream> action = Functor.ToAction(function);
+            Action<string, Stream> action = Functor.ToAction(function.Object);
             action(functionArg, Stream.Null);
 
-            function.VerifyAllExpectations();
+            function.VerifyAll();
         }
 
         /// <summary>
@@ -82,16 +82,16 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_ThreeArgs()
         {
-            Func<string, Stream, TextReader, int> function = MockRepository.GenerateMock<Func<string, Stream, TextReader, int>>();
+            Mock<Func<string, Stream, TextReader, int>> function = new Mock<Func<string, Stream, TextReader, int>>();
 
             string functionArg_1 = "first-arg";
             StreamReader functionArg_3 = new StreamReader(Stream.Null);
-            function.Expect(f => f(functionArg_1, Stream.Null, functionArg_3)).Return(0);
+            function.Setup(f => f(functionArg_1, Stream.Null, functionArg_3)).Returns(0).Verifiable();
 
-            Action<string, Stream, TextReader> action = Functor.ToAction(function);
+            Action<string, Stream, TextReader> action = Functor.ToAction(function.Object);
             action(functionArg_1, Stream.Null, functionArg_3);
 
-            function.VerifyAllExpectations();
+            function.VerifyAll();
         }
 
         /// <summary>
@@ -101,17 +101,17 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_FourArgs()
         {
-            Func<string, Stream, TextReader, DayOfWeek, int> function = MockRepository.GenerateMock<Func<string, Stream, TextReader, DayOfWeek, int>>();
+            Mock<Func<string, Stream, TextReader, DayOfWeek, int>> function = new Mock<Func<string, Stream, TextReader, DayOfWeek, int>>();
 
             string functionArg_1 = "first-arg";
             StreamReader functionArg_3 = new StreamReader(Stream.Null);
             DayOfWeek functionArg_4 = DayOfWeek.Friday;
-            function.Expect(f => f(functionArg_1, Stream.Null, functionArg_3, functionArg_4)).Return(0);
+            function.Setup(f => f(functionArg_1, Stream.Null, functionArg_3, functionArg_4)).Returns(0).Verifiable();
 
-            Action<string, Stream, TextReader, DayOfWeek> action = Functor.ToAction(function);
+            Action<string, Stream, TextReader, DayOfWeek> action = Functor.ToAction(function.Object);
             action(functionArg_1, Stream.Null, functionArg_3, functionArg_4);
 
-            function.VerifyAllExpectations();
+            function.VerifyAll();
         }
 
         /// <summary>
@@ -121,13 +121,11 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToAction_EventHandler()
         {
-            EventHandler<EventArgs> eventHandler = MockRepository.GenerateStub<EventHandler<EventArgs>>();
+            EventHandler<EventArgs> eventHandler = Mock.Of<EventHandler<EventArgs>>();
 
             Action<object, EventArgs> action = Functor.ToAction(eventHandler);
             Assert.That(action.Method, Is.SameAs(eventHandler.Method));
             Assert.That(action.Target, Is.SameAs(eventHandler.Target));
-
-            eventHandler.VerifyAllExpectations();
         }
 
         /// <summary>
@@ -136,13 +134,11 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToEventHandler()
         {
-            Action<object, EventArgs> action = MockRepository.GenerateStub<Action<object, EventArgs>>();
+            Action<object, EventArgs> action = Mock.Of<Action<object, EventArgs>>();
 
             EventHandler<EventArgs> eventHandler = Functor.ToEventHandler(action);
             Assert.That(eventHandler.Method, Is.SameAs(action.Method));
             Assert.That(eventHandler.Target, Is.SameAs(action.Target));
-
-            action.VerifyAllExpectations();
         }
 
         /// <summary>
@@ -151,7 +147,7 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToPredicate()
         {
-            Func<int, bool> functionPredicate = MockRepository.GenerateStub<Func<int, bool>>();
+            Func<int, bool> functionPredicate = Mock.Of<Func<int, bool>>();
 
             Predicate<int> predicate = Functor.ToPredicate(functionPredicate);
             Assert.That(predicate.Method, Is.SameAs(functionPredicate.Method));
@@ -164,7 +160,7 @@ namespace Jolt.Test.Functional
         [Test]
         public void ToPredicateFunc()
         {
-            Predicate<int> predicate = MockRepository.GenerateStub<Predicate<int>>();
+            Predicate<int> predicate = Mock.Of<Predicate<int>>();
 
             Func<int, bool> functionPredicate = Functor.ToPredicateFunc(predicate);
             Assert.That(functionPredicate.Method, Is.SameAs(predicate.Method));
@@ -257,73 +253,12 @@ namespace Jolt.Test.Functional
         }
 
         /// <summary>
-        /// Verifies the behavior of the NoOperation() method, for functions
-        /// that have zero arguments.
-        /// </summary>
-        [Test]
-        public void NoOperation_NoArgs()
-        {
-            Action no_op = Functor.NoOperation();
-            Assert.That(no_op.Target, Is.Null);
-            Assert.That(no_op.Method, Is.SameAs(GetNoOpMethod()));
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the NoOperation() method, for functions
-        /// that have one argument.
-        /// </summary>
-        [Test]
-        public void NoOperation_OneArg()
-        {
-            Action<int> no_op = Functor.NoOperation<int>();
-            Assert.That(no_op.Target, Is.Null);
-            Assert.That(no_op.Method, Is.SameAs(GetNoOpMethod(typeof(int))));
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the NoOperation() method, for functions
-        /// that have two arguments.
-        /// </summary>
-        [Test]
-        public void NoOperation_TwoArgs()
-        {
-            Action<int, char> no_op = Functor.NoOperation<int, char>();
-            Assert.That(no_op.Target, Is.Null);
-            Assert.That(no_op.Method, Is.SameAs(GetNoOpMethod(typeof(int), typeof(char))));
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the NoOperation() method, for functions
-        /// that have three arguments.
-        /// </summary>
-        [Test]
-        public void NoOperation_ThreeArgs()
-        {
-            Action<int, char, string> no_op = Functor.NoOperation<int, char, string>();
-            Assert.That(no_op.Target, Is.Null);
-            Assert.That(no_op.Method, Is.SameAs(GetNoOpMethod(typeof(int), typeof(char), typeof(string))));
-        }
-
-        /// <summary>
-        /// Verifies the behavior of the NoOperation() method, for functions
-        /// that have four arguments.
-        /// </summary>
-        [Test]
-        public void NoOperation_FourArgs()
-        {
-            Action<int, char, string, byte> no_op = Functor.NoOperation<int, char, string, byte>();
-            Assert.That(no_op.Target, Is.Null);
-            Assert.That(no_op.Method, Is.SameAs(GetNoOpMethod(typeof(int), typeof(char), typeof(string), typeof(byte))));
-        }
-
-        /// <summary>
         /// Verifies the behavior of the Identity() method.
         /// </summary>
         [Test]
         public void Identity()
         {
             Func<string, string> identity = Functor.Identity<string>();
-            Assert.That(identity.Target, Is.Null);
 
             for (int i = 0; i < 200; ++i)
             {
@@ -339,7 +274,6 @@ namespace Jolt.Test.Functional
         public void TrueForAll()
         {
             Func<int, bool> predicate = Functor.TrueForAll<int>();
-            Assert.That(predicate.Target, Is.Null);
 
             for (int i = 0; i < 200; ++i)
             {
@@ -354,7 +288,6 @@ namespace Jolt.Test.Functional
         public void FalseForAll()
         {
             Func<int, bool> predicate = Functor.FalseForAll<int>();
-            Assert.That(predicate.Target, Is.Null);
 
             for (int i = 0; i < 200; ++i)
             {

--- a/Jolt.Test/Jolt.Test.csproj
+++ b/Jolt.Test/Jolt.Test.csproj
@@ -1,126 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{A53A6CB3-346F-43B6-940A-066ADBE77FF0}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Jolt.Test</RootNamespace>
-    <AssemblyName>Jolt.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <StartupObject>
-    </StartupObject>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup>
+    <TargetFrameworks>net461;net48;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(ProjectDir)..\Jolt.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\Jolt.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
   <ItemGroup>
-    <ProjectReference Include="..\Jolt\Jolt.csproj">
-      <Project>{DA98557A-159C-4D4B-9663-7E7D479318CE}</Project>
-      <Name>Jolt</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Jolt\Jolt.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AbstractXDCReadPolicyTestFixture.cs" />
-    <Compile Include="ConvertTestFixture.cs" />
-    <Compile Include="DefaultXDCReadPolicyTestFixture.cs" />
-    <Compile Include="Functional\BindTestFixture.cs" />
-    <Compile Include="Functional\CompositeTestFixture.cs" />
-    <Compile Include="Functional\FunctorTestFixture.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestTypes.cs" />
-    <Compile Include="XmlDocCommentDirectoryElementCollectionTestFixture.cs" />
-    <Compile Include="XmlDocCommentDirectoryElementTestFixture.cs" />
-    <Compile Include="XmlDocCommentReaderSettingsTestFixture.cs" />
-    <Compile Include="XmlDocCommentReaderTestFixture.cs" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.4" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.21" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Rhino.Mocks">
-      <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
+    <None Remove="Xml\DocComments.xml" />
     <EmbeddedResource Include="Xml\DocComments.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Jolt.Test/Properties/AssemblyInfo.cs
+++ b/Jolt.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -18,5 +19,7 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("0.4.*")]
-[assembly: AssemblyFileVersion("0.4.*")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]
+
+[assembly: Parallelizable(ParallelScope.Children)]

--- a/Jolt.Test/TestTypes.cs
+++ b/Jolt.Test/TestTypes.cs
@@ -127,29 +127,6 @@ namespace Jolt.Test.Types
         private static readonly Type ThisType = typeof(FieldType<,>);
     }
 
-    internal unsafe abstract class PointerTestType<T>
-    {
-        public static ConstructorInfo Constructor { get { return ThisType.GetConstructors().Single(); } }
-        public static PropertyInfo Property { get { return ThisType.GetProperties().Single(p => p.GetIndexParameters().Length == 3); } }
-        public static MethodInfo Method { get { return ThisType.GetMethod("_method"); } }
-
-        #region property-encapsulated members -----------------------------------------------------
-
-        public PointerTestType(Action<T[]>[] t, out string***[][,][, ,] v) { v = null; }
-
-        public int this[int*[] t, Action<Action<T[]>[][]>[] a, short***[][,][, ,] v]
-        {
-            get { throw new NotImplementedException(); }
-            set { throw new NotImplementedException(); }
-        }
-
-        public void _method<U>(int x, ref T[,] t, out Action<U[][,]>*[,][] a, Action<int**[][, ,]> b) { a = null; }
-
-        #endregion
-
-        private static readonly Type ThisType = typeof(PointerTestType<>);
-    }
-
     internal abstract class __GenericTestType<R, S, T>
     {
         public static MethodInfo NonGenericFunction { get { return ThisType.GetMethod("_NonGenericFunction"); } }

--- a/Jolt.Test/packages.config
+++ b/Jolt.Test/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net35" />
-  <package id="RhinoMocks" version="3.6.1" targetFramework="net35" />
-</packages>

--- a/Jolt.sln.DotSettings
+++ b/Jolt.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/NUnitProvider/SetCurrentDirectoryTo/@EntryValue">TestFolder</s:String></wpf:ResourceDictionary>

--- a/Jolt/Functional/Compose.cs
+++ b/Jolt/Functional/Compose.cs
@@ -3924,7 +3924,7 @@ namespace Jolt.Functional
         /// 
         /// <param name="value">
         /// The inner function that participates in the composite.
-        /// </param
+        /// </param>
         /// 
         /// <returns>
         /// A functor f(w, x, y, s) equivalent to <paramref name="function"/>(w, x, y, <paramref name="value"/>(s)).

--- a/Jolt/Functional/Delegates.cs
+++ b/Jolt/Functional/Delegates.cs
@@ -170,7 +170,7 @@ namespace Jolt.Functional
 
     /// <summary>
     /// Encapsulates a method that has five parameters and returns a value
-    /// of the type specified by the <paramref name="TResult" /> parameter.
+    /// of the type specified by the <typeparamref name="TResult" /> parameter.
     /// </summary>
     /// 
     /// <typeparam name="TResult">
@@ -220,7 +220,7 @@ namespace Jolt.Functional
 
     /// <summary>
     /// Encapsulates a method that has six parameters and returns a value
-    /// of the type specified by the <paramref name="TResult" /> parameter.
+    /// of the type specified by the <typeparamref name="TResult" /> parameter.
     /// </summary>
     /// 
     /// <typeparam name="TResult">
@@ -278,7 +278,7 @@ namespace Jolt.Functional
 
     /// <summary>
     /// Encapsulates a method that has seven parameters and returns a value
-    /// of the type specified by the <paramref name="TResult" /> parameter.
+    /// of the type specified by the <typeparamref name="TResult" /> parameter.
     /// </summary>
     /// 
     /// <typeparam name="TResult">

--- a/Jolt/Jolt.csproj
+++ b/Jolt/Jolt.csproj
@@ -1,126 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{DA98557A-159C-4D4B-9663-7E7D479318CE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Jolt</RootNamespace>
-    <AssemblyName>Jolt</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Jolt.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Jolt.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(ProjectDir)..\Jolt.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>RedGate.ThirdParty.Jolt.Core</PackageId>
+    <PackageVersion>0.4.1</PackageVersion>
+    <Description>Contains commonly used classes and core library functionality.</Description>
+    <Copyright>Copyright © Steve Guidi 2008</Copyright>
+    <Authors>Redgate</Authors>
   </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\Jolt.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AbstractXDCReadPolicy.cs" />
-    <Compile Include="Convert.cs" />
-    <Compile Include="DefaultXDCReadPolicy.cs" />
-    <Compile Include="Functional\Bind.cs" />
-    <Compile Include="Functional\Compose.cs" />
-    <Compile Include="Functional\Delegates.cs" />
-    <Compile Include="Functional\Functor.cs" />
-    <Compile Include="IO\FileProxy.cs" />
-    <Compile Include="IO\IFile.cs" />
-    <Compile Include="IXmlDocCommentReader.cs" />
-    <Compile Include="IXmlDocCommentReadPolicy.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="XmlDocCommentDirectoryElement.cs" />
-    <Compile Include="XmlDocCommentDirectoryElementCollection.cs" />
-    <Compile Include="XmlDocCommentNames.cs" />
-    <Compile Include="XmlDocCommentReader.cs" />
-    <Compile Include="XmlDocCommentReaderSettings.cs" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
+    <None Remove="Xml\DocComments.xsd" />
     <EmbeddedResource Include="Xml\DocComments.xsd" />
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Jolt/Properties/AssemblyInfo.cs
+++ b/Jolt/Properties/AssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using0.3.* the '*' as shown below:
-[assembly: AssemblyVersion("0.4.0.1")]
-[assembly: AssemblyFileVersion("0.4.0.1")]
+[assembly: AssemblyVersion("0.4.1.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]
 
 // Friend assemblies.
 [assembly: InternalsVisibleTo("Jolt.Test,PublicKey=00240000048000009400000006020000002400005253413100040000010001001d177bb42749a6788ec732bff549851e2ce91f27bcfa0142fa5d094ece409c43486345f9cfb563c2efbeb684a1d27a677f5264d8060ccdc06fd4291f524bc402a7d31d3862a2a0ca1d3592e950b8ddd749e4eff943ba62a1f3c24ee70019c78107904a48f1a2ac1cf5b5a7717d82f451872dba59ad44fe836cbd6171b1e85dc9")]

--- a/Jolt/XmlDocCommentDirectoryElementCollection.cs
+++ b/Jolt/XmlDocCommentDirectoryElementCollection.cs
@@ -48,7 +48,7 @@ namespace Jolt
         #region ConfigurationElementCollection members --------------------------------------------
 
         /// <summary>
-        /// <see cref="ConfigurationElement.CreateNewElement()"/>
+        /// <see cref="ConfigurationElement.CreateNewElement"/>
         /// </summary>
         protected override ConfigurationElement CreateNewElement()
         {
@@ -56,7 +56,7 @@ namespace Jolt
         }
 
         /// <summary>
-        /// <see cref="ConfigurationElement.CreateNewElement(string)"/>
+        /// <see cref="ConfigurationElement.CreateNewElement"/>
         /// </summary>
         protected override ConfigurationElement CreateNewElement(string elementName)
         {
@@ -64,7 +64,7 @@ namespace Jolt
         }
 
         /// <summary>
-        /// <see cref="ConfigurationElement.GetElementKey(ConfigurationElement)"/>
+        /// <see cref="ConfigurationElement.GetElementKey"/>
         /// </summary>
         protected override object GetElementKey(ConfigurationElement element)
         {

--- a/Jolt/XmlDocCommentReader.cs
+++ b/Jolt/XmlDocCommentReader.cs
@@ -215,11 +215,11 @@ namespace Jolt
         }
 
         /// <summary>
-        /// Retrieves the xml doc comments for a given <see cref="System.Refection.EventInfo"/>.
+        /// Retrieves the xml doc comments for a given <see cref="System.Reflection.EventInfo"/>.
         /// </summary>
         /// 
         /// <param name="eventInfo">
-        /// The <see cref="System.Refection.EventInfo"/> for which the doc comments are retrieved.
+        /// The <see cref="System.Reflection.EventInfo"/> for which the doc comments are retrieved.
         /// </param>
         /// 
         /// <returns>


### PR DESCRIPTION
- Migrated from .NET Framework 3.5 to .NET Framework 4.6.1 and .NET Standard 2.0
- Updated project files to modern SDK format.
- NuGet package is now automatically built.
- Updated automated tests.
  - Migrated from Rhino Mocks to Moq, since the former doesn't support .NET Core.
  - Massively simplified the tests for the Compose functional helper class.
  - Removed some tests and some test assertions for compiler and/or runtime behaviour that's changed since CLR 2.0.
  - Changed the example assembly for some test fixtures since Rhino Mocks is no longer available, and the .xml doc comments file for some system types is not readily available by default.
- Fixed some minor XML Doc comment errors in the main Jolt project. **Note that there are no code changes to the Jolt project itself. All the work here was in the test project, which relied heavily on behaviour in CLR 2.0 and .NET Framework 3.5.**